### PR TITLE
Fix dialogue not closing after button interaction

### DIFF
--- a/src/cosmicpe/npcdialogue/player/PlayerInstance.php
+++ b/src/cosmicpe/npcdialogue/player/PlayerInstance.php
@@ -163,6 +163,7 @@ final class PlayerInstance{
 		if($info !== null && (int) $scene_name === $info->actor_runtime_id){
 			if(isset($info->dialogue->getButtons()[$index])){
 				$info->dialogue->onPlayerRespond($this->player, $index);
+				$this->removeCurrentDialogue();
 			}else{
 				$info->dialogue->onPlayerRespondInvalid($this->player, $index);
 			}


### PR DESCRIPTION
before pr, opening a dialogue and closing it without any button interaction works fine, but if you click a button while a dialogue is open and try to close it after, it wont work and youll be stuck in the dialogue screen

after pr, it closes the dialogue on any response (works, but if a user wants to do an action on button click without closes the dialogue, then they wont be able to.)

this was a quick personal fix, however ive seen others have the same issue, if they dont care about the limit mentioned above. this is will work fine.